### PR TITLE
修改了查找zlib相关文件的路径

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,9 @@ set(PNGLIB_NAME libpng${PNGLIB_MAJOR}${PNGLIB_MINOR})
 set(PNGLIB_VERSION ${PNGLIB_MAJOR}.${PNGLIB_MINOR}.${PNGLIB_RELEASE})
 
 # needed packages
-find_package(ZLIB REQUIRED)
+# find_package(ZLIB REQUIRED)
+set(ZLIB_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src/lib/zlib)
+set(ZLIB_LIBRARY ${CMAKE_BINARY_DIR}/src/lib/zlib/libz.so)
 include_directories(${ZLIB_INCLUDE_DIR})
 
 if(NOT WIN32)


### PR DESCRIPTION
注释掉了find_package(ZLIB)，将搜索路径改为RMC内部子模块路径。这样修改的弊端就是这个repo只能集成在RMC中进行编译，无法单独编译。